### PR TITLE
WebSocket client

### DIFF
--- a/src/main/java/org/webbitserver/netty/CatchingRunnable.java
+++ b/src/main/java/org/webbitserver/netty/CatchingRunnable.java
@@ -1,0 +1,20 @@
+package org.webbitserver.netty;
+
+public abstract class CatchingRunnable implements Runnable {
+    private final Thread.UncaughtExceptionHandler exceptionHandler;
+
+    public CatchingRunnable(Thread.UncaughtExceptionHandler exceptionHandler) {
+        this.exceptionHandler = exceptionHandler;
+    }
+
+    @Override
+    public void run() {
+        try {
+            go();
+        } catch (Throwable t) {
+            exceptionHandler.uncaughtException(Thread.currentThread(), t);
+        }
+    }
+
+    protected abstract void go() throws Throwable;
+}

--- a/src/main/java/org/webbitserver/netty/DecodingHybiFrame.java
+++ b/src/main/java/org/webbitserver/netty/DecodingHybiFrame.java
@@ -91,23 +91,4 @@ public class DecodingHybiFrame {
         };
     }
 
-
-    private abstract class CatchingRunnable implements Runnable {
-        private final Thread.UncaughtExceptionHandler exceptionHandler;
-
-        public CatchingRunnable(Thread.UncaughtExceptionHandler exceptionHandler) {
-            this.exceptionHandler = exceptionHandler;
-        }
-
-        @Override
-        public void run() {
-            try {
-                go();
-            } catch (Throwable t) {
-                exceptionHandler.uncaughtException(Thread.currentThread(), t);
-            }
-        }
-
-        protected abstract void go() throws Throwable;
-    }
 }

--- a/src/main/java/org/webbitserver/netty/NettyHttpControl.java
+++ b/src/main/java/org/webbitserver/netty/NettyHttpControl.java
@@ -93,7 +93,7 @@ public class NettyHttpControl implements HttpControl {
     @Override
     public NettyWebSocketConnection webSocketConnection() {
         if(nettyWebSocketConnection == null) {
-            nettyWebSocketConnection = new NettyWebSocketConnection(executor, nettyHttpRequest, ctx);
+            nettyWebSocketConnection = new NettyWebSocketConnection(executor, nettyHttpRequest, ctx, null);
         }
         return nettyWebSocketConnection;
     }

--- a/src/main/java/org/webbitserver/netty/NettyWebSocketChannelHandler.java
+++ b/src/main/java/org/webbitserver/netty/NettyWebSocketChannelHandler.java
@@ -80,7 +80,7 @@ public class NettyWebSocketChannelHandler extends SimpleChannelUpstreamHandler {
             this.webSocketConnection.setHybiWebSocketVersion(hybiVersion);
             upgradeResponseHybi(req, res, hybiVersion);
             ctx.getChannel().write(res);
-            adjustPipelineToWebSocket(ctx, new HybiWebSocketFrameDecoder(), new HybiWebSocketFrameEncoder());
+            adjustPipelineToWebSocket(ctx, HybiWebSocketFrameDecoder.serverSide(), new HybiWebSocketFrameEncoder());
         } else if (isHixie76WebSocketRequest(req)) {
             this.webSocketConnection.setVersion("HIXIE-76");
             upgradeResponseHixie76(req, res);
@@ -206,7 +206,10 @@ public class NettyWebSocketChannelHandler extends SimpleChannelUpstreamHandler {
         res.setStatus(new HttpResponseStatus(101, "Web Socket Protocol Handshake"));
         res.addHeader(UPGRADE, WEBSOCKET);
         res.addHeader(CONNECTION, HttpHeaders.Values.UPGRADE);
-        res.addHeader(WEBSOCKET_ORIGIN, req.getHeader(ORIGIN));
+        String origin = req.getHeader(ORIGIN);
+        if(origin != null) {
+            res.addHeader(WEBSOCKET_ORIGIN, origin);
+        }
         res.addHeader(WEBSOCKET_LOCATION, getWebSocketLocation(req));
         String protocol = req.getHeader(WEBSOCKET_PROTOCOL);
         if (protocol != null) {

--- a/src/main/java/org/webbitserver/wsclient/WebSocket.java
+++ b/src/main/java/org/webbitserver/wsclient/WebSocket.java
@@ -1,0 +1,169 @@
+package org.webbitserver.wsclient;
+
+import org.jboss.netty.bootstrap.ClientBootstrap;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ChannelHandler;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.channel.ChannelPipelineFactory;
+import org.jboss.netty.channel.ExceptionEvent;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
+import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
+import org.jboss.netty.handler.codec.http.HttpContentDecompressor;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpRequestEncoder;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseDecoder;
+import org.jboss.netty.handler.codec.http.HttpVersion;
+import org.webbitserver.WebSocketHandler;
+import org.webbitserver.handler.exceptions.PrintStackTraceExceptionHandler;
+import org.webbitserver.netty.CatchingRunnable;
+import org.webbitserver.netty.DecodingHybiFrame;
+import org.webbitserver.netty.HybiWebSocketFrameDecoder;
+import org.webbitserver.netty.HybiWebSocketFrameEncoder;
+import org.webbitserver.netty.NettyWebSocketConnection;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static org.jboss.netty.channel.Channels.pipeline;
+
+public class WebSocket {
+
+    private final ClientBootstrap bootstrap;
+    private final Channel channel;
+    private final WebSocketHandler webSocketHandler;
+    private final Executor executor;
+
+    public WebSocket(URI uri, WebSocketHandler webSocketHandler, Executor executor) {
+        this.webSocketHandler = webSocketHandler;
+        this.executor = executor;
+        String scheme = uri.getScheme() == null ? "ws" : uri.getScheme();
+        String host = uri.getHost() == null ? "localhost" : uri.getHost();
+        int port = uri.getPort();
+        if (port == -1) {
+            if (scheme.equalsIgnoreCase("ws")) {
+                port = 80;
+            } else if (scheme.equalsIgnoreCase("wss")) {
+                // port = 443;
+                throw new UnsupportedOperationException("SSL is not supported yet");
+            }
+        }
+
+        if (!scheme.equalsIgnoreCase("ws") && !scheme.equalsIgnoreCase("wss")) {
+            throw new IllegalArgumentException("Only ws(s) is supported.");
+        }
+
+        int mask = (int) (Math.random() * 0xFFFFFFFF);
+        // TODO: Write the mask to buffer
+        final byte[] outboundMaskingKey = new byte[]{1, 2, 3, 4};
+
+        bootstrap = new ClientBootstrap(new NioClientSocketChannelFactory(
+                Executors.newCachedThreadPool(),
+                Executors.newCachedThreadPool()));
+
+        bootstrap.setPipelineFactory(new ChannelPipelineFactory() {
+            public ChannelPipeline getPipeline() throws Exception {
+                ChannelPipeline pipeline = pipeline();
+                pipeline.addLast("decoder", new HttpResponseDecoder());
+                pipeline.addLast("encoder", new HttpRequestEncoder());
+                pipeline.addLast("inflater", new HttpContentDecompressor());
+                pipeline.addLast("handshakeHandler", new HandshakeChannelHandler(outboundMaskingKey));
+                return pipeline;
+            }
+        });
+        ChannelFuture future = bootstrap.connect(new InetSocketAddress(host, port));
+        channel = future.awaitUninterruptibly().getChannel();
+
+        if (!future.isSuccess()) {
+            close();
+            throw new RuntimeException(future.getCause());
+        }
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri.toASCIIString().replaceFirst("http", "ws"));
+        request.setHeader(HttpHeaders.Names.HOST, host);
+        request.setHeader(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+        request.setHeader(HttpHeaders.Names.ACCEPT_ENCODING, HttpHeaders.Values.GZIP);
+        request.setHeader("Sec-WebSocket-Version", 13);
+        request.setHeader("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ=="); // TODO: Generate a random key here
+
+        channel.write(request).awaitUninterruptibly();
+    }
+
+    public void close() {
+        channel.getCloseFuture().awaitUninterruptibly();
+        bootstrap.releaseExternalResources();
+    }
+
+    private class HandshakeChannelHandler extends SimpleChannelUpstreamHandler {
+        private final byte[] outboundMaskingKey;
+
+        public HandshakeChannelHandler(byte[] outboundMaskingKey) {
+            this.outboundMaskingKey = outboundMaskingKey;
+        }
+
+        @Override
+        public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
+            HttpResponse response = (HttpResponse) e.getMessage();
+            String webSocketAccept = response.getHeader("Sec-WebSocket-Accept"); // TODO: do something else if we didn't get one from the server
+            adjustPipelineToWebSocket(ctx, HybiWebSocketFrameDecoder.clientSide(outboundMaskingKey), new HybiWebSocketFrameEncoder());
+        }
+
+        private void adjustPipelineToWebSocket(ChannelHandlerContext ctx, ChannelHandler webSocketFrameDecoder, ChannelHandler webSocketFrameEncoder) {
+            final NettyWebSocketConnection webSocketConnection = new NettyWebSocketConnection(executor, null, ctx, outboundMaskingKey);
+            webSocketConnection.setHybiWebSocketVersion(13);
+
+            final Thread.UncaughtExceptionHandler exceptionHandler = new PrintStackTraceExceptionHandler();
+            ChannelHandler webSocketChannelHandler = new WebSocketChannelHandler(webSocketConnection, exceptionHandler);
+
+            ChannelPipeline p = ctx.getChannel().getPipeline();
+            p.remove("inflater");
+            p.replace("decoder", "wsdecoder", webSocketFrameDecoder);
+            p.replace("encoder", "wsencoder", webSocketFrameEncoder);
+            p.replace("handshakeHandler", "wshandler", webSocketChannelHandler);
+
+            executor.execute(new CatchingRunnable(exceptionHandler) {
+                @Override
+                public void go() throws Exception {
+                    webSocketHandler.onOpen(webSocketConnection);
+                }
+            });
+        }
+    }
+
+    private class WebSocketChannelHandler extends SimpleChannelUpstreamHandler {
+        private final NettyWebSocketConnection webSocketConnection;
+        private final Thread.UncaughtExceptionHandler exceptionHandler;
+
+        public WebSocketChannelHandler(NettyWebSocketConnection webSocketConnection, Thread.UncaughtExceptionHandler exceptionHandler) {
+            this.webSocketConnection = webSocketConnection;
+            this.exceptionHandler = exceptionHandler;
+        }
+
+        @Override
+        public void messageReceived(ChannelHandlerContext ctx, final MessageEvent e) throws Exception {
+            Object message = e.getMessage();
+            if (message instanceof DecodingHybiFrame) {
+                DecodingHybiFrame frame = (DecodingHybiFrame) message;
+                frame.dispatchMessage(webSocketHandler, webSocketConnection, executor, exceptionHandler);
+            }
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, final ExceptionEvent e) throws Exception {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    exceptionHandler.uncaughtException(Thread.currentThread(), e.getCause());
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/org/webbitserver/wsclient/WebSocket.java
+++ b/src/main/java/org/webbitserver/wsclient/WebSocket.java
@@ -153,6 +153,8 @@ public class WebSocket {
             if (message instanceof DecodingHybiFrame) {
                 DecodingHybiFrame frame = (DecodingHybiFrame) message;
                 frame.dispatchMessage(webSocketHandler, webSocketConnection, executor, exceptionHandler);
+            } else {
+                throw new IllegalStateException("BAD MESSAGE");
             }
         }
 

--- a/src/main/java/org/webbitserver/wsclient/WebSocket.java
+++ b/src/main/java/org/webbitserver/wsclient/WebSocket.java
@@ -61,9 +61,7 @@ public class WebSocket {
             throw new IllegalArgumentException("Only ws(s) is supported.");
         }
 
-        int mask = (int) (Math.random() * 0xFFFFFFFF);
-        // TODO: Write the mask to buffer
-        final byte[] outboundMaskingKey = new byte[]{1, 2, 3, 4};
+        final byte[] outboundMaskingKey = new byte[]{randomByte(), randomByte(), randomByte(), randomByte()};
 
         bootstrap = new ClientBootstrap(new NioClientSocketChannelFactory(
                 Executors.newCachedThreadPool(),
@@ -95,6 +93,10 @@ public class WebSocket {
         request.setHeader("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ=="); // TODO: Generate a random key here
 
         channel.write(request).awaitUninterruptibly();
+    }
+
+    private byte randomByte() {
+        return (byte) (Math.random() * 256);
     }
 
     public void close() {
@@ -150,12 +152,8 @@ public class WebSocket {
         @Override
         public void messageReceived(ChannelHandlerContext ctx, final MessageEvent e) throws Exception {
             Object message = e.getMessage();
-            if (message instanceof DecodingHybiFrame) {
-                DecodingHybiFrame frame = (DecodingHybiFrame) message;
-                frame.dispatchMessage(webSocketHandler, webSocketConnection, executor, exceptionHandler);
-            } else {
-                throw new IllegalStateException("BAD MESSAGE");
-            }
+            DecodingHybiFrame frame = (DecodingHybiFrame) message;
+            frame.dispatchMessage(webSocketHandler, webSocketConnection, executor, exceptionHandler);
         }
 
         @Override

--- a/src/test/java/org/webbitserver/wsclient/WebSocketTest.java
+++ b/src/test/java/org/webbitserver/wsclient/WebSocketTest.java
@@ -1,0 +1,76 @@
+package org.webbitserver.wsclient;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.webbitserver.WebSocketConnection;
+import org.webbitserver.WebSocketHandler;
+import samples.echo.EchoWsServer;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.Thread.sleep;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class WebSocketTest {
+    private EchoWsServer server;
+    private URI wsUri;
+
+    @Before
+    public void start() throws IOException, URISyntaxException, InterruptedException {
+        server = new EchoWsServer(59509);
+        URI uri = server.start();
+        wsUri = new URI(uri.toASCIIString().replaceFirst("http", "ws"));
+    }
+
+    @After
+    public void die() throws IOException, InterruptedException {
+        server.stop();
+    }
+
+    @Test
+    public void sendsAndReceivesTextMessages() throws InterruptedException {
+        final CountDownLatch countDown = new CountDownLatch(2);
+
+        new WebSocket(wsUri, new WebSocketHandler() {
+            @Override
+            public void onOpen(WebSocketConnection connection) throws Exception {
+                System.out.println("AHOY");
+                connection.send("You are Alexander Yalt?");
+                countDown.countDown();
+            }
+
+            @Override
+            public void onClose(WebSocketConnection connection) throws Exception {
+                System.out.println("CLOSE");
+            }
+
+            @Override
+            public void onMessage(WebSocketConnection connection, String msg) throws Throwable {
+                System.out.println("msg = " + msg);
+                assertEquals("You are Alexander Yalt?", msg);
+                countDown.countDown();
+            }
+
+            @Override
+            public void onMessage(WebSocketConnection connection, byte[] msg) throws Throwable {
+            }
+
+            @Override
+            public void onPong(WebSocketConnection connection, String msg) throws Throwable {
+            }
+        }, Executors.newSingleThreadExecutor());
+//        boolean completed = countDown.await(1000, TimeUnit.MILLISECONDS);
+//        System.out.println("completed = " + completed);
+//        System.out.println("countDown = " + countDown.getCount());
+//        assertFalse("Didn't count down: " + countDown.getCount(), completed);
+
+        sleep(2000);
+    }
+}

--- a/src/test/java/org/webbitserver/wsclient/WebSocketTest.java
+++ b/src/test/java/org/webbitserver/wsclient/WebSocketTest.java
@@ -14,9 +14,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.Thread.sleep;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class WebSocketTest {
     private EchoWsServer server;
@@ -41,19 +40,16 @@ public class WebSocketTest {
         new WebSocket(wsUri, new WebSocketHandler() {
             @Override
             public void onOpen(WebSocketConnection connection) throws Exception {
-                System.out.println("AHOY");
                 connection.send("You are Alexander Yalt?");
                 countDown.countDown();
             }
 
             @Override
             public void onClose(WebSocketConnection connection) throws Exception {
-                System.out.println("CLOSE");
             }
 
             @Override
             public void onMessage(WebSocketConnection connection, String msg) throws Throwable {
-                System.out.println("msg = " + msg);
                 assertEquals("You are Alexander Yalt?", msg);
                 countDown.countDown();
             }
@@ -66,11 +62,6 @@ public class WebSocketTest {
             public void onPong(WebSocketConnection connection, String msg) throws Throwable {
             }
         }, Executors.newSingleThreadExecutor());
-//        boolean completed = countDown.await(1000, TimeUnit.MILLISECONDS);
-//        System.out.println("completed = " + completed);
-//        System.out.println("countDown = " + countDown.getCount());
-//        assertFalse("Didn't count down: " + countDown.getCount(), completed);
-
-        sleep(2000);
+        assertTrue(countDown.await(1000, TimeUnit.MILLISECONDS));
     }
 }

--- a/src/test/java/samples/echo/EchoWsServer.java
+++ b/src/test/java/samples/echo/EchoWsServer.java
@@ -19,7 +19,6 @@ public class EchoWsServer {
 
     public EchoWsServer(int port) throws IOException {
         webServer = createWebServer(port)
-                .add(new LoggingHandler(new SimpleLogSink()))
                 .add(new HttpToWebSocketHandler(new EchoHandler())).connectionExceptionHandler(new PrintStackTraceExceptionHandler());
     }
 

--- a/src/test/java/samples/echo/EchoWsServer.java
+++ b/src/test/java/samples/echo/EchoWsServer.java
@@ -1,0 +1,59 @@
+package samples.echo;
+
+import org.webbitserver.WebServer;
+import org.webbitserver.WebSocketConnection;
+import org.webbitserver.WebSocketHandler;
+import org.webbitserver.handler.HttpToWebSocketHandler;
+import org.webbitserver.handler.exceptions.PrintStackTraceExceptionHandler;
+import org.webbitserver.handler.logging.LoggingHandler;
+import org.webbitserver.handler.logging.SimpleLogSink;
+
+import java.io.IOException;
+import java.net.URI;
+
+import static org.webbitserver.WebServers.createWebServer;
+
+public class EchoWsServer {
+
+    private final WebServer webServer;
+
+    public EchoWsServer(int port) throws IOException {
+        webServer = createWebServer(port)
+                .add(new LoggingHandler(new SimpleLogSink()))
+                .add(new HttpToWebSocketHandler(new EchoHandler())).connectionExceptionHandler(new PrintStackTraceExceptionHandler());
+    }
+
+    public URI start() throws IOException {
+        webServer.start();
+        return webServer.getUri();
+    }
+
+    public void stop() throws IOException, InterruptedException {
+        webServer.stop().join();
+    }
+
+    private static class EchoHandler implements WebSocketHandler {
+        @Override
+        public void onOpen(WebSocketConnection connection) throws Exception {
+        }
+
+        @Override
+        public void onClose(WebSocketConnection connection) throws Exception {
+        }
+
+        @Override
+        public void onMessage(WebSocketConnection connection, String msg) throws Exception {
+            connection.send(msg);
+        }
+
+        @Override
+        public void onMessage(WebSocketConnection connection, byte[] msg) {
+            connection.send(msg);
+        }
+
+        @Override
+        public void onPong(WebSocketConnection connection, String msg) {
+            connection.ping(msg);
+        }
+    }
+}

--- a/src/test/java/samples/echo/Main.java
+++ b/src/test/java/samples/echo/Main.java
@@ -1,45 +1,13 @@
 package samples.echo;
 
-import org.webbitserver.WebServer;
-import org.webbitserver.WebSocketConnection;
-import org.webbitserver.WebSocketHandler;
-import org.webbitserver.handler.HttpToWebSocketHandler;
-import org.webbitserver.handler.exceptions.PrintStackTraceExceptionHandler;
-
-import static org.webbitserver.WebServers.createWebServer;
-
 /**
  * Simple Echo server to be used with the Autobahn test suite.
  */
 public class Main {
 
     public static void main(String[] args) throws Exception {
-        WebServer webServer = createWebServer(9001).add(new HttpToWebSocketHandler(new WebSocketHandler() {
-            @Override
-            public void onOpen(WebSocketConnection connection) throws Exception {
-            }
-
-            @Override
-            public void onClose(WebSocketConnection connection) throws Exception {
-            }
-
-            @Override
-            public void onMessage(WebSocketConnection connection, String msg) throws Exception {
-                connection.send(msg);
-            }
-
-            @Override
-            public void onMessage(WebSocketConnection connection, byte[] msg) {
-                connection.send(msg);
-            }
-
-            @Override
-            public void onPong(WebSocketConnection connection, String msg) {
-                connection.ping(msg);
-            }
-        })).connectionExceptionHandler(new PrintStackTraceExceptionHandler()).start();
-
-        System.out.println("Echo server running on: " + webServer.getUri());
+        EchoWsServer server = new EchoWsServer(9001);
+        System.out.println("Echo server running on: " + server.start());
     }
 
 }


### PR DESCRIPTION
This pull request implements a WebSocket client based on the same codec that is used in the server. Potential use cases:
- point-to-point communication between server processes (we've been limited to browsers so far)
- testing websocket servers

I'm not 100% happy with the API (See `org.webbitserver.wsclient.WebSocketTest`). The `WebSocket` instrance isn't used, and the programmer is interacting with the `WebSocketHandler` and `WebSocketConnection` instead, which is the same API as is used on the server.

Comments/suggestions?
